### PR TITLE
Update used libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ '7', '8']
-
-    name: Java ${{ matrix.java }} build with Maven
+    name: Java 8 build with Maven
     env:
       MAVEN_OPTS: '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
 
@@ -25,15 +21,38 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java }}
-          distribution: 'zulu'
+          java-version: '8'
+          distribution: 'adopt'
       - name: Build with Maven
-        run: mvn site --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
+        run: mvn test --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
       - name: Check for vulnerabilities
         run: mvn org.sonatype.ossindex.maven:ossindex-maven-plugin:audit
+
+  update-site:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Site build with Maven
+    if: github.ref == 'refs/heads/master'
+    env:
+      MAVEN_OPTS: '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: site-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            site-${{ runner.os }}-maven-
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+      - name: Generate site with Maven
+        run: mvn test org.pitest:pitest-maven:mutationCoverage site --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
       - name: Deploy docs 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.4
-        if: github.ref == 'refs/heads/master' && matrix.java == '7'
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: target/site # The folder the action should deploy.
@@ -55,10 +74,10 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '8'
-      - name: Coverage with Cobertura Maven plugin
-        run: mvn cobertura:cobertura --quiet --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
+      - name: Coverage with Jacoco Maven plugin
+        run: mvn verify jacoco:report --quiet --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
       - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-          file: ./**/target/site/cobertura/cobertura.xml
+          file: ./**/target/site/jacoco/jacoco.xml
           name: codecov

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
@@ -98,31 +98,48 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>addPitReport</id>
+            <activation>
+                <file>
+                    <exists>target/pit-reports</exists>
+                </file>
+            </activation>
+
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>report</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
     </profiles>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.2</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- we prefer hamcrest-library as it is more complete -->
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -132,24 +149,32 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <!-- junit5 requires updated surefire -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.9.1</version>
+            </plugin>
             <!-- release + sign -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <!-- DO NOT USE <2.5, see https://jira.codehaus.org/browse/MRELEASE-812 -->
-                <version>2.5.1</version>
+                <version>3.0.0-M4</version>
                 <configuration>
                     <!--
                         Commenting this out so this will be asked interactively
                         <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
                         -->
-                    <!-- see http://jira.codehaus.org/browse/MGPG-9 -->
                     <mavenExecutorId>forked-path</mavenExecutorId>
                 </configuration>
             </plugin>
@@ -157,7 +182,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -170,7 +195,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -184,7 +209,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.14</version>
+                <version>3.0.0-M5</version>
                 <executions>
                     <execution>
                         <goals>
@@ -203,16 +228,16 @@
                 </executions>
             </plugin>
             <plugin>
-                <!--
-                    pitest doesn't (yet) support maven site goal,
-                    so we can only run it for local checking.
-                    See https://github.com/hcoles/pitest/issues/10
-
-                    Run with mvn org.pitest:pitest-maven:scmMutationCoverage
-                -->
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
-                <version>1.1.2</version>
+                <version>1.6.7</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>0.14</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <targetClasses>
                         <param>fi.eis.libraries*</param>
@@ -234,43 +259,45 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <format>xml</format>
-                    <maxmem>256m</maxmem>
-                </configuration>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
     <reporting>
         <plugins>
-            <!-- as exampled in http://www.mkyong.com/qa/maven-cobertura-code-coverage-example/ -->
-            <!-- Normally, we take off the dependency report, saves time. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
+                <version>3.1.2</version>
             </plugin>
-
-            <!-- integrate maven-cobertura-plugin to project site -->
-            <!--
-              note a known problem with UTF-8, https://github.com/cobertura/cobertura/issues/111, which is
-              currently only fixed in cobertura trunk -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
                 <configuration>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                    </formats>
-                    <check/>
+                    <reportSets>
+                        <reportSet>
+                            <reports>
+                                <report>report</report>
+                            </reports>
+                        </reportSet>
+                    </reportSets>
                 </configuration>
             </plugin>
             <plugin>
@@ -279,10 +306,11 @@
                 <version>2.1</version>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.2.0</version>
             </plugin>
         </plugins>
     </reporting>
+
 </project>

--- a/src/test/java/fi/eis/libraries/di/DIClassScanningJarLoadingTest.java
+++ b/src/test/java/fi/eis/libraries/di/DIClassScanningJarLoadingTest.java
@@ -1,10 +1,13 @@
 package fi.eis.libraries.di;
 
+import fi.eis.libraries.di.testhelpers.MockClassInNeedOfDependency;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.io.File;
 
-import fi.eis.libraries.di.testhelpers.MockClassInNeedOfDependency;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 
 /**
  * Creation Date: 1.12.2014
@@ -19,10 +22,11 @@ public class DIClassScanningJarLoadingTest {
         Context diContext = DependencyInjection.deploymentUnitContext(
                 new File(this.getClass().getResource("/minimal-di-1.0-SNAPSHOT-test-targets.jar").getPath()));
         MockClassInNeedOfDependency instance = diContext.get(MockClassInNeedOfDependency.class);
-        Assert.assertNotNull("was not initialized: " + instance, instance.dependency);
+        assertNotNull(instance.dependency, "was not initialized: " + instance);
     }
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testDiWithNonExistingFile() {
-        DependencyInjection.deploymentUnitContext(new File("does-not-exist"));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> DependencyInjection.deploymentUnitContext(new File("does-not-exist")));
     }
 }

--- a/src/test/java/fi/eis/libraries/di/DIClassScanningTest.java
+++ b/src/test/java/fi/eis/libraries/di/DIClassScanningTest.java
@@ -1,17 +1,18 @@
 package fi.eis.libraries.di;
 
+import fi.eis.libraries.di.SimpleLogger.LogLevel;
+import fi.eis.libraries.di.testhelpers.MockClassInNeedOfDependency;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
-import fi.eis.libraries.di.SimpleLogger.LogLevel;
-import fi.eis.libraries.di.testhelpers.MockClassInNeedOfDependency;
-
-import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Creation Date: 1.12.2014
@@ -25,13 +26,13 @@ public class DIClassScanningTest {
     public void testDi() {
         Context diContext = DependencyInjection.deploymentUnitContext(this.getClass());
         MockClassInNeedOfDependency instance = diContext.get(MockClassInNeedOfDependency.class);
-        Assert.assertNotNull("was not initialized: " + instance, instance.dependency);
+        assertNotNull(instance.dependency, "was not initialized: " + instance);
     }
     private PrintStream originalPrintStream;
     private ByteArrayOutputStream loggingOutputStream;
     
     // redirect System.out to capture any logging
-    @Before
+    @BeforeEach
     public void setupSystemOutRedirection() {
         originalPrintStream = System.out;
         
@@ -40,7 +41,7 @@ public class DIClassScanningTest {
         System.setOut(ps);
     }
     
-    @After
+    @AfterEach
     public void resetSystemOutRedirection() {
         System.setOut(originalPrintStream);
     }
@@ -54,10 +55,10 @@ public class DIClassScanningTest {
         String loggedStuff = loggingOutputStream.toString("UTF-8");
         
         // there should be at least a context.get call
-        Assert.assertThat(loggedStuff, Matchers.containsString("context.get"));
+        assertThat(loggedStuff, Matchers.containsString("context.get"));
         
         // and path handling
-        Assert.assertThat(loggedStuff, Matchers.containsString("Handle path"));
+        assertThat(loggedStuff, Matchers.containsString("Handle path"));
     }
     @Test
     public void testDiLoggingDisabled() throws UnsupportedEncodingException {
@@ -68,8 +69,8 @@ public class DIClassScanningTest {
         // after tests, we check what was logged
         String loggedStuff = loggingOutputStream.toString("UTF-8");
         
-        Assert.assertThat(loggedStuff, Matchers.not(Matchers.containsString("context.get")));
-        Assert.assertThat(loggedStuff, Matchers.not(Matchers.containsString("Handle path")));
+        assertThat(loggedStuff, Matchers.not(Matchers.containsString("context.get")));
+        assertThat(loggedStuff, Matchers.not(Matchers.containsString("Handle path")));
     }
     @Test
     public void testDiLoggingDefault() throws UnsupportedEncodingException {
@@ -80,7 +81,7 @@ public class DIClassScanningTest {
         // after tests, we check what was logged
         String loggedStuff = loggingOutputStream.toString("UTF-8");
         
-        Assert.assertThat(loggedStuff, Matchers.not(Matchers.containsString("context.get")));
-        Assert.assertThat(loggedStuff, Matchers.not(Matchers.containsString("Handle path")));
+        assertThat(loggedStuff, Matchers.not(Matchers.containsString("context.get")));
+        assertThat(loggedStuff, Matchers.not(Matchers.containsString("Handle path")));
     }
 }

--- a/src/test/java/fi/eis/libraries/di/DIConstructorTest.java
+++ b/src/test/java/fi/eis/libraries/di/DIConstructorTest.java
@@ -13,12 +13,14 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import fi.eis.libraries.di.SimpleLogger.LogLevel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 interface ConstDependencyInterface {
@@ -71,7 +73,7 @@ public class DIConstructorTest {
         Module mClasses = DependencyInjection.classes(ConstClassToInit.class);
         Context diContext = DependencyInjection.context(mClasses, mSuppliers);
         ConstClassToInit instance = diContext.get(ConstClassToInit.class);
-        Assert.assertNotNull("was not initialized: " + instance, instance.getDependency());
+        assertNotNull(instance.getDependency(), "was not initialized: " + instance);
     }
 
     @Test
@@ -83,14 +85,14 @@ public class DIConstructorTest {
         Module mClasses = DependencyInjection.classes(ConstClassToInit.class);
         Context diContext = DependencyInjection.context(mClasses, mSuppliers);
         ConstClassToInit instance = diContext.get(ConstClassToInit.class);
-        Assert.assertNotNull("was not initialized: " + instance, instance.getDependency());
+        assertNotNull( instance.getDependency(), "was not initialized: " + instance);
     }
 
     // below is to test logging
 
     private PrintStream originalPrintStream;
     private ByteArrayOutputStream loggingOutputStream;
-    @Before
+    @BeforeEach
     public void setupSystemOutRedirection() {
         originalPrintStream = System.out;
         
@@ -99,7 +101,7 @@ public class DIConstructorTest {
         System.setOut(ps);
     }
     
-    @After
+    @AfterEach
     public void resetSystemOutRedirection() {
         System.setOut(originalPrintStream);
     }
@@ -117,7 +119,7 @@ public class DIConstructorTest {
         
         String loggedStuff = loggingOutputStream.toString("UTF-8");
         // there should be at least a context.get call
-        Assert.assertThat(loggedStuff, Matchers.containsString("context.get"));
+        assertThat(loggedStuff, Matchers.containsString("context.get"));
     }
     @Test
     public void testDiWithLoggingDisabled() throws UnsupportedEncodingException {
@@ -132,7 +134,7 @@ public class DIConstructorTest {
         diContext.get(ConstClassToInit.class);
         
         String loggedStuff = loggingOutputStream.toString("UTF-8");
-        Assert.assertThat(loggedStuff, Matchers.not(
+        assertThat(loggedStuff, Matchers.not(
                 Matchers.containsString("context.get")));
     }
     @Test
@@ -146,7 +148,7 @@ public class DIConstructorTest {
         diContext.get(ConstClassToInit.class);
         
         String loggedStuff = loggingOutputStream.toString("UTF-8");
-        Assert.assertThat(loggedStuff, Matchers.not(
+        assertThat(loggedStuff, Matchers.not(
                 Matchers.containsString("context.get")));
     }
 }

--- a/src/test/java/fi/eis/libraries/di/DIInheritanceTest.java
+++ b/src/test/java/fi/eis/libraries/di/DIInheritanceTest.java
@@ -1,15 +1,15 @@
 package fi.eis.libraries.di;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 /**
  * Creation Date: 30.11.2014
  * Creation Time: 21:21
  *
  * @author eis
  */
-
-
-import org.junit.Assert;
-import org.junit.Test;
 
 
 interface DependencyInterface {
@@ -54,7 +54,7 @@ public class DIInheritanceTest {
         Module mClasses = DependencyInjection.classes(ClassToInit.class);
         Context diContext = DependencyInjection.context(mClasses, mSuppliers);
         ClassToInit instance = diContext.get(ClassToInit.class);
-        Assert.assertNotNull("was not initialized: " + instance, instance.getDependency());
+        assertNotNull(instance.getDependency(), "was not initialized: " + instance);
     }
 
     @Test
@@ -65,6 +65,6 @@ public class DIInheritanceTest {
         Module mClasses = DependencyInjection.classes(ClassToInit.class);
         Context diContext = DependencyInjection.context(mClasses, mSuppliers);
         ClassToInit instance = diContext.get(ClassToInit.class);
-        Assert.assertNotNull("was not initialized: " + instance, instance.getDependency());
+        assertNotNull(instance.getDependency(), "was not initialized: " + instance);
     }
 }

--- a/src/test/java/fi/eis/libraries/di/JavaConfigTest.java
+++ b/src/test/java/fi/eis/libraries/di/JavaConfigTest.java
@@ -3,15 +3,17 @@ package fi.eis.libraries.di;
 import fi.eis.libraries.di.testhelpers.DependencyMock;
 import fi.eis.libraries.di.testhelpers.DependencyMockInterface;
 import fi.eis.libraries.di.testhelpers.MockClassInNeedOfConstructorDependency;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class JavaConfigTest {
     @Test
     public void testJavaConfig() {
         Context diContext = DependencyInjection.configurationClasses(SimpleLogger.LogLevel.DEBUG, ExampleJavaConfig.class);
         MockClassInNeedOfConstructorDependency instance = diContext.get(MockClassInNeedOfConstructorDependency.class);
-        Assert.assertTrue("was not initialized: " + instance, instance.hasDependency());
+        assertTrue(instance.hasDependency(), "was not initialized: " + instance);
     }
 }
 

--- a/src/test/java/fi/eis/libraries/di/SimpleLoggerTest.java
+++ b/src/test/java/fi/eis/libraries/di/SimpleLoggerTest.java
@@ -5,48 +5,51 @@ import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
 
 import fi.eis.libraries.di.SimpleLogger.LogLevel;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleLoggerTest {
     @Test
     public void testDebugLevelDebugLogging() throws UnsupportedEncodingException {
         SimpleLogger logger = new SimpleLogger(this.getClass());
         logger.setLogLevel(LogLevel.DEBUG);
-        Assert.assertTrue(logger.isDebugEnabled());
-        Assert.assertTrue(logger.isErrorEnabled());
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isErrorEnabled());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
         logger.setPrintOut(ps);
         logger.debug("Hello");
         logger.debug("How're you doing, %s?", "John");
         String result = baos.toString("UTF-8");
-        Assert.assertThat(result, Matchers.containsString("DEBUG"));
-        Assert.assertThat(result, Matchers.containsString("How're you doing, John?"));
+        assertThat(result, Matchers.containsString("DEBUG"));
+        assertThat(result, Matchers.containsString("How're you doing, John?"));
     }
     @Test
     public void testErrorLevelDebugLogging() throws UnsupportedEncodingException {
         SimpleLogger logger = new SimpleLogger(this.getClass());
         logger.setLogLevel(LogLevel.ERROR);
-        Assert.assertFalse(logger.isDebugEnabled());
-        Assert.assertTrue(logger.isErrorEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertTrue(logger.isErrorEnabled());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
         logger.setPrintOut(ps);
         logger.debug("Hello");
         logger.debug("How're you doing, %s?", "John");
         String result = baos.toString("UTF-8");
-        Assert.assertThat(result, Matchers.not(Matchers.containsString("DEBUG")));
-        Assert.assertThat(result, Matchers.not(Matchers.containsString("How're you doing, John?")));
+        assertThat(result, Matchers.not(Matchers.containsString("DEBUG")));
+        assertThat(result, Matchers.not(Matchers.containsString("How're you doing, John?")));
     }
     @Test
     public void testErrorLevelErrorLogging() throws UnsupportedEncodingException {
         SimpleLogger logger = new SimpleLogger(this.getClass());
         logger.setLogLevel(LogLevel.ERROR);
-        Assert.assertFalse(logger.isDebugEnabled());
-        Assert.assertTrue(logger.isErrorEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertTrue(logger.isErrorEnabled());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
         logger.setPrintOut(ps);
@@ -54,8 +57,8 @@ public class SimpleLoggerTest {
         logger.debug("How're you doing, %s?", "John");
         logger.error("Quite well, %s.", "Matt");
         String result = baos.toString("UTF-8");
-        Assert.assertThat(result, Matchers.not(Matchers.containsString("DEBUG")));
-        Assert.assertThat(result, Matchers.not(Matchers.containsString("How're you doing, John?")));
-        Assert.assertThat(result, Matchers.containsString("Quite well, Matt."));
+        assertThat(result, Matchers.not(Matchers.containsString("DEBUG")));
+        assertThat(result, Matchers.not(Matchers.containsString("How're you doing, John?")));
+        assertThat(result, Matchers.containsString("Quite well, Matt."));
     }
 }


### PR DESCRIPTION
JUnit5 requires Java 8, so this means dropping Java 7 support.