### PR TITLE
Feature/update dependencies without junit5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '7', '8']
+        java: [ '7', '8', '11', '16']
 
     name: Java ${{ matrix.java }} build with Maven
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,33 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
       - name: Build with Maven
-        run: mvn site --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
+        run: mvn test --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
       - name: Check for vulnerabilities
         run: mvn org.sonatype.ossindex.maven:ossindex-maven-plugin:audit
-      - name: Deploy docs 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.4
-        if: github.ref == 'refs/heads/master' && matrix.java == '7'
+
+  update-site:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Site build with Maven
+    if: github.ref == 'refs/heads/master'
+    env:
+      MAVEN_OPTS: '-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: target/site # The folder the action should deploy.
+          path: ~/.m2/repository
+          key: site-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            site-${{ runner.os }}-maven-
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+      - name: Generate site with Maven
+        run: mvn test org.pitest:pitest-maven:mutationCoverage site --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
 
   coverage:
     needs: build
@@ -55,8 +73,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '8'
-      - name: Coverage with Cobertura Maven plugin
-        run: mvn cobertura:cobertura --quiet --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
+      - name: Coverage with Jacoco Maven plugin
+        run: mvn verify jacoco:report --quiet --batch-mode -DbuildNumber=${GITHUB_RUN_NUMBER}
       - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,30 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>addPitReport</id>
+            <activation>
+                <file>
+                    <exists>target/pit-reports</exists>
+                </file>
+            </activation>
+
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                        <reportSets>
+                            <reportSet>
+                                <reports>
+                                    <report>report</report>
+                                </reports>
+                            </reportSet>
+                        </reportSets>
+                    </plugin>
+                </plugins>
+            </reporting>
+        </profile>
     </profiles>
     <dependencies>
         <dependency>
@@ -116,13 +140,13 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -132,18 +156,26 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.9.1</version>
+            </plugin>
             <!-- release + sign -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <!-- DO NOT USE <2.5, see https://jira.codehaus.org/browse/MRELEASE-812 -->
-                <version>2.5.1</version>
+                <version>3.0.0-M4</version>
                 <configuration>
                     <!--
                         Commenting this out so this will be asked interactively
@@ -157,7 +189,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -170,7 +202,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -184,7 +216,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.14</version>
+                <version>3.0.0-M5</version>
                 <executions>
                     <execution>
                         <goals>
@@ -203,16 +235,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <!--
-                    pitest doesn't (yet) support maven site goal,
-                    so we can only run it for local checking.
-                    See https://github.com/hcoles/pitest/issues/10
-
-                    Run with mvn org.pitest:pitest-maven:scmMutationCoverage
-                -->
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
-                <version>1.1.2</version>
+                <version>1.6.7</version>
                 <configuration>
                     <targetClasses>
                         <param>fi.eis.libraries*</param>
@@ -234,44 +259,45 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <format>xml</format>
-                    <maxmem>256m</maxmem>
-                </configuration>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
     <reporting>
         <plugins>
-            <!-- as exampled in http://www.mkyong.com/qa/maven-cobertura-code-coverage-example/ -->
-            <!-- Normally, we take off the dependency report, saves time. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
-                </configuration>
+                <version>3.1.2</version>
             </plugin>
 
-            <!-- integrate maven-cobertura-plugin to project site -->
-            <!--
-              note a known problem with UTF-8, https://github.com/cobertura/cobertura/issues/111, which is
-              currently only fixed in cobertura trunk -->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                    </formats>
-                    <check/>
-                </configuration>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -279,9 +305,14 @@
                 <version>2.1</version>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.4</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.2.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-maven</artifactId>
+                <version>1.6.7</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
JUnit5 requires Java 8, which we don't want to require just for the sake of JUnit.